### PR TITLE
Add texlive and latexmk to support building PDF docs

### DIFF
--- a/hpx_build_env/Dockerfile
+++ b/hpx_build_env/Dockerfile
@@ -43,6 +43,9 @@ RUN export DEBIAN_FRONTEND=noninteractive &&        \
                     python-sphinx                   \
                     python-sphinx-rtd-theme         \
                     python-breathe                  \
+                    texlive                         \
+                    texlive-latex-extra             \
+                    latexmk                         \
                     libjson-perl                    \
                     ninja-build                     \
                     git                             \


### PR DESCRIPTION
This is unfortunately quite a big dependency. If pulling the image for each step in our CircleCI builds becomes unbearably slow, it might in fact be faster to install the dependencies for the PDF docs step only.

Needs some more packages, investigating which.