### PR TITLE
Install 'python3-dev'.

### DIFF
--- a/hpx_build_env/Dockerfile
+++ b/hpx_build_env/Dockerfile
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive &&        \
                     mpi-default-dev                 \
                     doxygen                         \
                     python3                         \
+                    python3-dev                     \
                     python3-pip                     \
                     texlive                         \
                     texlive-latex-extra             \


### PR DESCRIPTION
To avoid version mismatch for applications that need Python headers.