### PR TITLE
build: install sphinxcontrib-bibtex using pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
         environment:
             IMAGE_FOLDER_NAME: hip_hpx_build_env
             IMAGE_NAME_LATEST: stellargroup/hip_build_env:latest
-            IMAGE_NAME_VERSIONED: stellargroup/hip_build_env:9
+            IMAGE_NAME_VERSIONED: stellargroup/hip_build_env:10
         steps:
             - checkout
             - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
         environment:
             IMAGE_FOLDER_NAME: hpx_build_env
             IMAGE_NAME_LATEST: stellargroup/build_env:latest
-            IMAGE_NAME_VERSIONED: stellargroup/build_env:9
+            IMAGE_NAME_VERSIONED: stellargroup/build_env:10
         steps:
             - checkout
             - setup_remote_docker

--- a/hip_hpx_build_env/Dockerfile
+++ b/hip_hpx_build_env/Dockerfile
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-FROM stellargroup/build_env:9
+FROM stellargroup/build_env:10
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/hpx_build_env/Dockerfile
+++ b/hpx_build_env/Dockerfile
@@ -91,7 +91,7 @@ RUN wget -q https://github.com/mozilla/grcov/releases/download/v0.7.1/grcov-linu
 # handling "friend struct x;", see
 # https://github.com/michaeljones/breathe/issues/521. The pinned version can be
 # removed when the issue has been resolved.
-RUN pip3 install sphinx==3.5.4 breathe==4.16.0 sphinx-rtd-theme sphinx-book-theme insegel cmake_format && \
+RUN pip3 install sphinx==3.5.4 breathe==4.16.0 sphinx-rtd-theme sphinx-book-theme sphinxcontrib-bibtex insegel cmake_format && \
     rm /usr/bin/ld && ln -s /usr/bin/ld.lld /usr/bin/ld && cd /tmp && \
     git clone https://github.com/tomtom-international/cpp-dependencies.git && \
     cd cpp-dependencies && cmake . && make -j install && \


### PR DESCRIPTION
This change installs `sphinxcontrib-bibtex` using `pip`.
Refer to https://github.com/STEllAR-GROUP/hpx/pull/5626.