### PR TITLE
Update Sphinx version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
         environment:
             IMAGE_FOLDER_NAME: hpx_build_env
             IMAGE_NAME_LATEST: stellargroup/build_env:latest
-            IMAGE_NAME_VERSIONED: stellargroup/build_env:11
+            IMAGE_NAME_VERSIONED: stellargroup/build_env:12
         steps:
             - checkout
             - setup_remote_docker
@@ -49,7 +49,7 @@ jobs:
         environment:
             IMAGE_FOLDER_NAME: hip_hpx_build_env
             IMAGE_NAME_LATEST: stellargroup/hip_build_env:latest
-            IMAGE_NAME_VERSIONED: stellargroup/hip_build_env:11
+            IMAGE_NAME_VERSIONED: stellargroup/hip_build_env:12
         steps:
             - checkout
             - setup_remote_docker

--- a/hip_hpx_build_env/Dockerfile
+++ b/hip_hpx_build_env/Dockerfile
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-FROM stellargroup/build_env:11
+FROM stellargroup/build_env:12
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/hpx_build_env/Dockerfile
+++ b/hpx_build_env/Dockerfile
@@ -88,11 +88,7 @@ RUN wget -q https://github.com/mozilla/grcov/releases/download/v0.7.1/grcov-linu
     mv grcov /usr/bin && \
     rm grcov.tar.bz2
 
-# NOTE: breathe is pinned to 4.16.0 as 4.17.0 introduced a regression in
-# handling "friend struct x;", see
-# https://github.com/michaeljones/breathe/issues/521. The pinned version can be
-# removed when the issue has been resolved.
-RUN pip3 install sphinx==3.5.4 breathe==4.16.0 sphinx-rtd-theme sphinx-book-theme sphinxcontrib-bibtex insegel cmake_format && \
+RUN pip3 install sphinx==3.5.4 breathe==4.16.0 sphinx-book-theme sphinxcontrib-bibtex cmake_format && \
     rm /usr/bin/ld && ln -s /usr/bin/ld.lld /usr/bin/ld && cd /tmp && \
     git clone https://github.com/tomtom-international/cpp-dependencies.git && \
     cd cpp-dependencies && cmake . && make -j install && \


### PR DESCRIPTION
Updating the version of sphinx requires the version of breathe to be updated as well. 

The new versions are: `sphinx==4.5.0` and `breathe==4.33.1`.

The sphinx themes `sphinx-rtd-theme` and `insegel` are not needed, so they are removed. We only need `sphinx-book-theme`.