### PR TITLE
ci: install `tex-gyre` package & bump docker image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
         environment:
             IMAGE_FOLDER_NAME: hpx_build_env
             IMAGE_NAME_LATEST: stellargroup/build_env:latest
-            IMAGE_NAME_VERSIONED: stellargroup/build_env:12
+            IMAGE_NAME_VERSIONED: stellargroup/build_env:13
         steps:
             - checkout
             - setup_remote_docker
@@ -49,7 +49,7 @@ jobs:
         environment:
             IMAGE_FOLDER_NAME: hip_hpx_build_env
             IMAGE_NAME_LATEST: stellargroup/hip_build_env:latest
-            IMAGE_NAME_VERSIONED: stellargroup/hip_build_env:12
+            IMAGE_NAME_VERSIONED: stellargroup/hip_build_env:13
         steps:
             - checkout
             - setup_remote_docker

--- a/hip_hpx_build_env/Dockerfile
+++ b/hip_hpx_build_env/Dockerfile
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-FROM stellargroup/build_env:12
+FROM stellargroup/build_env:13
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/hpx_build_env/Dockerfile
+++ b/hpx_build_env/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update -qq && apt-get install -y -qq    \
                     texlive                         \
                     texlive-latex-extra             \
                     latexmk                         \
+                    tex-gyre                        \
                     libjson-perl                    \
                     ninja-build                     \
                     codespell                       \


### PR DESCRIPTION
Documentation PDF generation was failing because of a missing package (`tex-gyre`) that contained a font file (`tgtermes.sty`) required. Assuming generation was going through at some point, the file may have been moved to a separate package by maintainers or a dependency might have started utilizing it in between.

Added the package to install command and bumped image version.

Also see https://github.com/STEllAR-GROUP/hpx/pull/5959